### PR TITLE
Filter iframe messages

### DIFF
--- a/js/iframeResizeInner.js
+++ b/js/iframeResizeInner.js
@@ -30,7 +30,10 @@
         height = currentHeight;
 
         // pass a message with the height to the parent window.
-        window.parent.postMessage(height, "*");
+        window.parent.postMessage({
+          type: 'iFrameResizeHeight', // Include for filtering.
+          height: height
+        }, "*");
       }
     }, 500);
   }

--- a/js/iframeResizeOuter.js
+++ b/js/iframeResizeOuter.js
@@ -11,23 +11,27 @@
   // This code assumes there is only a single iframe on the page.
   var iframe = document.querySelector("iframe");
 
+  // Sets the corrected height of the iframe.
+  function resizeIframe (height){
+
+    // Compute the correction for the iframe border.
+    var border = parseFloat(getComputedStyle(iframe).borderWidth);
+    var borderCorrection = isNaN(border) ? 0 : border * 2;
+    height = height + borderCorrection;
+
+    // Set the iframe height to the height from the message.
+    iframe.setAttribute("height", height);
+  }
+
   // If an iframe is there...
   if (iframe) {
 
     // Listen for messages from the inner iframe.
     // See https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
     window.addEventListener("message", function (event) {
-
-      // The data passed in the message is the height.
-      var height = event.data;
-
-      // Compute the correction for the iframe border.
-      var border = parseFloat(getComputedStyle(iframe).borderWidth);
-      var borderCorrection = isNaN(border) ? 0 : border * 2;
-      height = height + borderCorrection;
-
-      // Set the iframe height to the height from the message.
-      iframe.setAttribute("height", height);
+      if (event.data.type === 'iFrameResizeHeight') {
+        resizeIframe(event.data.height);
+      }
     }, false);
   }
 }());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dataviz-styleguide",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataviz-styleguide",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Branding guidelines for data visualisation.",
   "main": "index.js",
   "scripts": {

--- a/test/embeddedViz.html
+++ b/test/embeddedViz.html
@@ -42,5 +42,14 @@
       <div class="four wide column gridtest"><p>Test</p></div>
     </div>
     <script src="../js/iframeResizeInner.js"></script>
+    <script>
+
+      // Test that messages not sent by iframeResizeInner.js
+      // get filtered out and are ignored.
+      setTimeout(function (){
+        window.parent.postMessage('someOtherMessage', '*');
+      }, 1000);
+
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Ignore messages not sent by our code.

This will fix some bad behavior observed when embedding visualizations in the data portal, where there appears to be other code using `window.postMessage` for other purposes.